### PR TITLE
Add exit codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/j-dunham/openai-cli/cmd"
 	"github.com/joho/godotenv"
@@ -12,13 +13,13 @@ func main() {
 	err := godotenv.Load()
 	if err != nil {
 		fmt.Println("Error loading .env file:", err)
-		return
+		os.Exit(1)
 	}
 	prompt := flag.String("prompt", "", "The prompt to ask ChatGPT.")
 	flag.Parse()
 	if *prompt == "" {
 		fmt.Println("You must provide a prompt to ask ChatGPT.")
-		return
+		os.Exit(2)
 	}
 
 	cmd.Execute(*prompt)


### PR DESCRIPTION
Currently the app always returns the exit code `0`, which is common for when a command runs successfully. This adds exit codes in the cases when

- there is an error loading the `.env` file
- there is no prompt

```
go build . 

./openai-cli 
Error loading .env file: open .env: no such file or directory

echo $?
1
```

```
./openai-cli 
You must provide a prompt to ask ChatGPT.

echo $?
2
```