### PR TITLE
Add SQLite option to store prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 **/**/openai-cli
+*.db
+*.sqlite

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
+github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -3,10 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
-
 	"github.com/j-dunham/openai-cli/cmd"
 	"github.com/joho/godotenv"
+	"os"
 )
 
 func main() {
@@ -16,11 +15,13 @@ func main() {
 		os.Exit(1)
 	}
 	prompt := flag.String("prompt", "", "The prompt to ask ChatGPT.")
+	save := flag.Bool("save", false, "Save the prompt and response to the database.")
+
 	flag.Parse()
 	if *prompt == "" {
 		fmt.Println("You must provide a prompt to ask ChatGPT.")
 		os.Exit(2)
 	}
 
-	cmd.Execute(*prompt)
+	cmd.Execute(*prompt, *save)
 }

--- a/util/db.go
+++ b/util/db.go
@@ -1,0 +1,110 @@
+package util
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const file = "prompt.db"
+const table = "prompts"
+
+type Prompt struct {
+	ID        string
+	Prompt    string
+	Response  string
+	CreatedAt time.Time
+}
+
+func id() (id string) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func openDB() (db *sql.DB) {
+	db, err := sql.Open("sqlite3", file)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return db
+}
+
+func execute_sql(sql string, args ...interface{}) (rows sql.Result, err error) {
+	db := openDB()
+	defer db.Close()
+
+	res, err := db.Exec(sql, args...)
+	if err != nil {
+		err = fmt.Errorf("execute_sql: %s .. %s", err, sql)
+		log.Fatal(err)
+	}
+	return res, err
+}
+
+func query_db(sql string) (rows *sql.Rows) {
+	db := openDB()
+	defer db.Close()
+
+	rows, err := db.Query(sql)
+	if err != nil {
+		err = fmt.Errorf("query_db: %s", err)
+		log.Fatal(err)
+	}
+	return rows
+}
+
+func CreateTable() {
+	tableSql := fmt.Sprintf("SELECT name FROM sqlite_master WHERE type='table' AND name='%s'", table)
+	rows := query_db(tableSql)
+	defer rows.Close()
+
+	exists := rows.Next()
+	if exists {
+		return
+	}
+
+	createSql := fmt.Sprintf("CREATE TABLE %s (id TEXT PRIMARY KEY, prompt TEXT, response TEXT, CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP)", table)
+	execute_sql(createSql)
+}
+
+func InsertPrompt(prompt string, response string) (int64, error) {
+	insertSql := fmt.Sprintf("INSERT INTO %s (id, prompt, response) VALUES (?, ?, ?)", table)
+	res, err := execute_sql(insertSql, id(), prompt, response)
+	if err != nil {
+		log.Fatal("failed to insert prompt")
+	}
+
+	idx, err := res.LastInsertId()
+	if err != nil {
+		log.Fatal("failed to insert prompt")
+	}
+	return idx, err
+}
+
+func ReadeadPrompts() (prompts []Prompt, err error) {
+	db := openDB()
+	defer db.Close()
+
+	rows := query_db(fmt.Sprintf("SELECT * FROM %s ORDER BY CreatedAt DESC", table))
+	defer rows.Close()
+
+	prompts = make([]Prompt, 0)
+	for rows.Next() {
+		var p Prompt
+		err = rows.Scan(&p.ID, &p.Prompt, &p.Response, &p.CreatedAt)
+		if err != nil {
+			log.Fatal(err)
+		}
+		prompts = append(prompts, p)
+	}
+	return prompts, err
+}


### PR DESCRIPTION
## What's Changing
- Adds a `-save` flag to indicate that the prompt should be stored in a SQLite DB.   
- Adds functions to create the prompt table and insert and read prompts.

I think the next step would be to allow a user to include prompts as context in the current prompt request. Also maybe allow a user to display old prompts.

I wasn't sure where to put the db functions so I stuck it in the util package, which didn't seem great?